### PR TITLE
[DAT-1569] - use injected clover keys

### DIFF
--- a/Doppler.CloverAPI/appsettings.int.json
+++ b/Doppler.CloverAPI/appsettings.int.json
@@ -1,7 +1,4 @@
 {
-  "LogglyConfig": {
-    "CustomerToken": "REPLACE_WITH_CUSTOMER_TOKEN"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -11,10 +8,8 @@
       }
     }
   },
-  "AllowedHosts": "*",
   "DopplerSecurity": {
-    "PublicKeysFolder": "public-keys",
-    "PublicKeysFilenameRegex": "\\.xml$"
+    "PublicKeysFolder": "public-keys-dev"
   },
   "CloverSettings": {
     "CreateCardTokenUrl": "https://token-sandbox.dev.clover.com/v1/tokens",
@@ -22,7 +17,7 @@
     "CreateCustomerUrl": "https://scl-sandbox.dev.clover.com/v1/customers",
     "GetPaymentUrl": "https://sandbox.dev.clover.com/v3/merchants/{0}/customers?filter=emailAddress={1}",
     "ApiAccessKey": "REPLACE_FOR_API_ACCESS_KEY",
-    "EcommerceApiToken": "REPLACE_FOR_ECOMMERCE_API_TOKEN",
+    "EcommerceApiToken": "REPLACE_FOR_ECOMMERCE_API_KEY",
     "MerchantId": "REPLACE_FOR_MERCHANT_ID"
   }
 }

--- a/Doppler.CloverAPI/appsettings.json
+++ b/Doppler.CloverAPI/appsettings.json
@@ -17,10 +17,10 @@
     "PublicKeysFilenameRegex": "\\.xml$"
   },
   "CloverSettings": {
-    "CreateCardTokenUrl": "https://token-sandbox.dev.clover.com/v1/tokens",
-    "CreatePaymentUrl": "https://scl-sandbox.dev.clover.com/v1/charges",
-    "CreateCustomerUrl": "https://scl-sandbox.dev.clover.com/v1/customers",
-    "GetPaymentUrl": "https://sandbox.dev.clover.com/v3/merchants/{0}/customers?filter=emailAddress={1}",
+    "CreateCardTokenUrl": "https://token.clover.com/v1/tokens",
+    "CreatePaymentUrl": "https://scl.clover.com/v1/charges",
+    "CreateCustomerUrl": "https://scl.clover.com/v1/customers",
+    "GetPaymentUrl": "https://api.clover.com/v3/merchants/{0}/customers?filter=emailAddress={1}",
     "ApiAccessKey": "REPLACE_FOR_API_ACCESS_KEY",
     "EcommerceApiToken": "REPLACE_FOR_ECOMMERCE_API_TOKEN",
     "MerchantId": "REPLACE_FOR_MERCHANT_ID"

--- a/Doppler.CloverAPI/appsettings.qa.json
+++ b/Doppler.CloverAPI/appsettings.qa.json
@@ -1,7 +1,4 @@
 {
-  "LogglyConfig": {
-    "CustomerToken": "REPLACE_WITH_CUSTOMER_TOKEN"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",
@@ -11,10 +8,8 @@
       }
     }
   },
-  "AllowedHosts": "*",
   "DopplerSecurity": {
-    "PublicKeysFolder": "public-keys",
-    "PublicKeysFilenameRegex": "\\.xml$"
+    "PublicKeysFolder": "public-keys-dev"
   },
   "CloverSettings": {
     "CreateCardTokenUrl": "https://token-sandbox.dev.clover.com/v1/tokens",


### PR DESCRIPTION
[DAT-1569](https://makingsense.atlassian.net/browse/DAT-1569)

Create int and qa appsettings to use swarm injected clover keys.

Also changed the urls for the correct env.
Documentation for prod urls: https://docs.clover.com/reference/api-reference-overview#sandbox-base-urls

[DAT-1569]: https://makingsense.atlassian.net/browse/DAT-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ