### PR TITLE
[No-ticket] - use appsettings.json configs that dont change for int and qa

### DIFF
--- a/Doppler.CloverAPI/appsettings.int.json
+++ b/Doppler.CloverAPI/appsettings.int.json
@@ -1,16 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
-    }
-  },
-  "DopplerSecurity": {
-    "PublicKeysFolder": "public-keys-dev"
-  },
   "CloverSettings": {
     "CreateCardTokenUrl": "https://token-sandbox.dev.clover.com/v1/tokens",
     "CreatePaymentUrl": "https://scl-sandbox.dev.clover.com/v1/charges",

--- a/Doppler.CloverAPI/appsettings.qa.json
+++ b/Doppler.CloverAPI/appsettings.qa.json
@@ -1,16 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
-      }
-    }
-  },
-  "DopplerSecurity": {
-    "PublicKeysFolder": "public-keys-dev"
-  },
   "CloverSettings": {
     "CreateCardTokenUrl": "https://token-sandbox.dev.clover.com/v1/tokens",
     "CreatePaymentUrl": "https://scl-sandbox.dev.clover.com/v1/charges",


### PR DESCRIPTION
The int and qa appsettings were searching the public jwt key for verifiying a token's signature in the folder `public-keys-dev` instead of `public-keys`. The DopplerSecurity section on the int and qa appsettings were deleted in order to use the appsettings.json one